### PR TITLE
Updated the contracts to use CrossDomainOwnableLinea

### DIFF
--- a/src/LineaStateBridge.sol
+++ b/src/LineaStateBridge.sol
@@ -8,6 +8,7 @@ import { ILineaWorldID } from "./interfaces/ILineaWorldID.sol";
 import { IRootHistory } from "world-id-state-bridge/interfaces/IRootHistory.sol";
 import { IWorldIDIdentityManager } from "world-id-state-bridge/interfaces/IWorldIDIdentityManager.sol";
 import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import { LineaWorldID } from "./LineaWorldID.sol";
 
 /// @title World ID State Bridge Linea
 /// @author Worldcoin & James Harrison
@@ -136,30 +137,17 @@ contract LineaStateBridge is Ownable2Step {
         emit RootPropagated(latestRoot);
     }
 
-    /// @notice Adds functionality to the StateBridge to transfer ownership
-    /// of LineaWorldID to another contract on L1 or to a local Linea Stack chain EOA
-    /// @dev  _messageService should be hardcoded to 0x508Ca82Df566dCD1B0DE8296e70a96332cD644ec for L2 Linea
-    /// @dev _remoteSender should be address of L1 LineaStateBridge
-    /// @custom:revert if _owner is set to the zero address
-    function transferOwnershipLinea(address _messageService, address _remoteSender) external onlyOwner {
-        if (_remoteSender == address(0) || _messageService == address(0)) {
-            revert AddressZero();
-        }
+    /// @notice Allows for ownership to be transferred with specifying the locality.
+    /// @param _owner   The new owner of the contract.
+    /// @param _isLocal Configures the locality of the ownership.
+    function transferOwnership(address _owner, bool _isLocal) external onlyOwner {
+        LineaWorldID(lineaWorldIDAddress).transferOwnership(_owner, _isLocal);
+    }
 
-        // The `encodeCall` function is strongly typed, so this checks that we are passing the
-        // correct data to the Linea Stack chain bridge.
-        bytes memory message =
-            abi.encodeCall(MessageServiceBase.updateMessageServiceBase, (_messageService, _remoteSender));
-
-        IMessageService(messageServiceAddress).sendMessage(
-            // Contract address on the Linea Stack Chain
-            lineaWorldIDAddress,
-            _gasLimitTransferOwnership,
-            message
-        );
-
-        emit UpdatedRemoteAddressLinea(owner(), _remoteSender);
-        emit UpdatedMessageServiceLinea(owner(), _messageService);
+    /// @notice Sets or updates the messaging service
+    /// @param _messageService The new message service address, cannot be empty.
+    function setMessagingService(address _messageService) public onlyOwner {
+        LineaWorldID(lineaWorldIDAddress).setMessagingService(_messageService);
     }
 
     /// @notice Adds functionality to the StateBridge to set the root history expiry on LineaWorldID

--- a/src/interfaces/ICrossDomainOwnableLinea.sol
+++ b/src/interfaces/ICrossDomainOwnableLinea.sol
@@ -1,9 +1,6 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-/// @title Interface for the LineaWorldID contract
-/// @author Worldcoin and 0xprinc x James Harrison.
-/// @notice Interface for the MessageServiceBase contract for the Linea L2
 interface ICrossDomainOwnableLinea {
     /// @notice Allows for ownership to be transferred with specifying the locality.
     /// @param _owner   The new owner of the contract.

--- a/src/interfaces/ICrossDomainOwnableLinea.sol
+++ b/src/interfaces/ICrossDomainOwnableLinea.sol
@@ -1,0 +1,16 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+/// @title Interface for the LineaWorldID contract
+/// @author Worldcoin and 0xprinc x James Harrison.
+/// @notice Interface for the MessageServiceBase contract for the Linea L2
+interface ICrossDomainOwnableLinea {
+    /// @notice Allows for ownership to be transferred with specifying the locality.
+    /// @param _owner   The new owner of the contract.
+    /// @param _isLocal Configures the locality of the ownership.
+    function transferOwnership(address _owner, bool _isLocal) external;
+
+    /// @notice Sets or updates the messaging service
+    /// @param _messageService The new message service address, cannot be empty.
+    function setMessagingService(address _messageService) external;
+}


### PR DESCRIPTION


Resolves #25

## Tasks
1. For `LineaWorldID` (L2):
   - [ x] Inherit from `CrossDomainOwnableLinea`
   - [x ] Change `onlyMessagingService onlyAuthorizedRemoteSender` to `onlyOwner`
2. For `LineaStateBridge` (L1):
   - [x ] Split `transferOwnershipLinea` into two methods:
     - [x ] Simple `transferOwnership`
     - [ x] `setMessagingService` that calls corresponding methods on L2 contracts inherited from `CrossDomainOwnableLinea`
3. - [ x] Update any related tests to reflect these changes
4. - [x ] Ensure all existing functionality remains intact

This PR Updates the contracts to use CrossDomainOwnableLinea

