### PR TITLE
default config init

### DIFF
--- a/src/script/config/default-mainnet-config.json
+++ b/src/script/config/default-mainnet-config.json
@@ -1,7 +1,5 @@
 {
-  "worldIDIdentityManagerAddress": "0xMainnetWorldIDAddress",
-  "lineaStateBridgeAddress": "0xMainnetStateBridgeAddress",
-  "lineaWorldIDAddress": "0xMainnetWorldIDAddress",
-  "ethereumRpcUrl": "https://mainnet.infura.io/v3/YOUR_INFURA_PROJECT_ID",
-  "lineaRpcUrl": "https://linea-mainnet.infura.io/v3/YOUR_INFURA_PROJECT_ID"
+  "worldIDIdentityManagerAddress": "0x163b09b4fE21177c455D850BD815B6D583732432",
+  "messageServiceAddressL1": "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
+  "messageServiceAddressL2": "0x508Ca82Df566dCD1B0DE8296e70a96332cD644ec"
 }

--- a/src/script/config/default-mainnet-config.json
+++ b/src/script/config/default-mainnet-config.json
@@ -1,0 +1,7 @@
+{
+  "worldIDIdentityManagerAddress": "0xMainnetWorldIDAddress",
+  "lineaStateBridgeAddress": "0xMainnetStateBridgeAddress",
+  "lineaWorldIDAddress": "0xMainnetWorldIDAddress",
+  "ethereumRpcUrl": "https://mainnet.infura.io/v3/YOUR_INFURA_PROJECT_ID",
+  "lineaRpcUrl": "https://linea-mainnet.infura.io/v3/YOUR_INFURA_PROJECT_ID"
+}

--- a/src/script/config/default-sepolia-config.json
+++ b/src/script/config/default-sepolia-config.json
@@ -1,0 +1,7 @@
+{
+  "worldIDIdentityManagerAddress": "0xSepoliaWorldIDAddress",
+  "lineaStateBridgeAddress": "0xSepoliaStateBridgeAddress",
+  "lineaWorldIDAddress": "0xSepoliaWorldIDAddress",
+  "ethereumRpcUrl": "https://sepolia.infura.io/v3/YOUR_INFURA_PROJECT_ID",
+  "lineaRpcUrl": "https://linea-sepolia.infura.io/v3/YOUR_INFURA_PROJECT_ID"
+}

--- a/src/script/config/default-sepolia-config.json
+++ b/src/script/config/default-sepolia-config.json
@@ -1,7 +1,5 @@
 {
-  "worldIDIdentityManagerAddress": "0xSepoliaWorldIDAddress",
-  "lineaStateBridgeAddress": "0xSepoliaStateBridgeAddress",
-  "lineaWorldIDAddress": "0xSepoliaWorldIDAddress",
-  "ethereumRpcUrl": "https://sepolia.infura.io/v3/YOUR_INFURA_PROJECT_ID",
-  "lineaRpcUrl": "https://linea-sepolia.infura.io/v3/YOUR_INFURA_PROJECT_ID"
+  "worldIDIdentityManagerAddress": "0xb2ead588f14e69266d1b87936b75325181377076",
+  "messageServiceAddressL1": "0xB218f8A4Bc926cF1cA7b3423c154a0D627Bdb7E5",
+  "messageServiceAddressL2": "0x971e727e956690b9957be6d51Ec16E73AcAC83A7"
 }

--- a/src/script/deploy.js
+++ b/src/script/deploy.js
@@ -145,15 +145,6 @@ async function getLineaStateBridgeAddress(config) {
   }
 }
 
-async function getWorldIDIdentityManagerAddress(config) {
-  if (!config.worldIDIdentityManagerAddress) {
-    config.worldIDIdentityManagerAddress = process.env.WORLD_ID_IDENTITY_MANAGER_ADDRESS;
-  }
-  if (!config.worldIDIdentityManagerAddress) {
-    config.worldIDIdentityManagerAddress = await ask("Enter WorldID Identity Manager Address: ");
-  }
-}
-
 ///////////////////////////////////////////////////////////////////
 ///                            UTILS                            ///
 ///////////////////////////////////////////////////////////////////
@@ -287,7 +278,6 @@ async function deploymentMainnet(config) {
   await getTreeDepth(config);
   await saveConfiguration(config);
   await deployLineaWorldID(config);
-  await getWorldIDIdentityManagerAddress(config);
   await getLineaWorldIDAddress(config);
   await saveConfiguration(config);
   await deployLineaStateBridgeMainnet(config);

--- a/src/script/deploy.js
+++ b/src/script/deploy.js
@@ -157,9 +157,18 @@ async function getWorldIDIdentityManagerAddress(config) {
 ///////////////////////////////////////////////////////////////////
 ///                            UTILS                            ///
 ///////////////////////////////////////////////////////////////////
-async function loadConfiguration(useConfig) {
+async function loadConfiguration(useConfig, environment) {
   if (!useConfig) {
     return {};
+  }
+  const defaultConfigFile = `src/script/config/default-${environment}-config.json`;
+  if (!fs.existsSync(CONFIG_FILENAME)) {
+    if (fs.existsSync(defaultConfigFile)) {
+      fs.copyFileSync(defaultConfigFile, CONFIG_FILENAME);
+      console.log(`Default configuration for ${environment} copied to ${CONFIG_FILENAME}`);
+    } else {
+      console.warn(`Default configuration file for ${environment} not found.`);
+    }
   }
   let answer = await ask(`Do you want to load configuration from prior runs? [Y/n]: `, "bool");
   const spinner = ora("Configuration Loading").start();
@@ -296,15 +305,17 @@ async function main() {
 
   program
     .name("deploy")
-    .description("A CLI interface for deploying the WorldID state bridge on Linea mainnet.")
-    .option("--no-config", "Do not use any existing configuration.");
+    .description("A CLI interface for deploying the WorldID state bridge on Linea.")
+    .option("--no-config", "Do not use any existing configuration.")
+    .option("--env <environment>", "Specify the environment (e.g., mainnet, sepolia)", "mainnet");
 
   program
     .command("deploy")
     .description("Interactively deploys the WorldID state bridge on Linea mainnet.")
     .action(async () => {
       const options = program.opts();
-      let config = await loadConfiguration(options.config);
+      const environment = options.env || "mainnet";
+      let config = await loadConfiguration(options.config, environment);
       await deploymentMainnet(config);
       await saveConfiguration(config);
     });


### PR DESCRIPTION
- Resolves #40 
- Inititalizes default-config files for mainnet and sepolia.
- Involves network specific components in default config, rest are kept in env.
- Introduces env option in CLI to select between deployment networks.
- Copies and initializes default config as per env specified in CLI for deployment.