### PR TITLE
fix: make event and method names and fields consistent

### DIFF
--- a/src/LineaStateBridge.sol
+++ b/src/LineaStateBridge.sol
@@ -50,13 +50,12 @@ contract LineaStateBridge is Ownable2Step {
     /// of the LineaWorldID contract to the WorldID Identity Manager contract
     /// @param previousRemoteAddress The previous authorized remote sender for the LineaWorldID contract
     /// @param remoteAddress The authorized remote sender address, cannot be empty
-    event UpdatedRemoteAddressLinea(address indexed previousRemoteAddress, address indexed remoteAddress);
+    event OwnershipTransferredLinea(address indexed previousRemoteAddress, address indexed remoteAddress, bool isLocal);
 
     /// @notice Emitted when the StateBridge changes message service address
     /// of the LineaWorldID contract
-    /// @param previousMessageService The previous message service address for the LineaWorldID contract
     /// @param messageService The message service address, cannot be empty.
-    event UpdatedMessageServiceLinea(address indexed previousMessageService, address indexed messageService);
+    event MessageServiceUpdatedLinea(address indexed messageService);
 
     /// @notice Emitted when the StateBridge sends a root to the LineaWorldID contract
     /// @param root The root sent to the LineaWorldID contract on Linea
@@ -122,8 +121,8 @@ contract LineaStateBridge is Ownable2Step {
     ///                          PUBLIC API                         ///
     ///////////////////////////////////////////////////////////////////
 
-    /// @notice Sends the latest WorldID Identity Manager root to the ILineaStack.
-    /// @dev Calls this method on the L1 Proxy contract to relay roots to Linea
+    /// @notice Sends the latest WorldID Identity Manager root to the World ID contract on Linea.
+    /// @dev Uses the Linea message service to relay the latest root to the LineaWorldID contract on L2
     function propagateRoot() external payable {
         uint256 latestRoot = IWorldIDIdentityManager(worldIDAddress).latestRoot();
 
@@ -158,12 +157,12 @@ contract LineaStateBridge is Ownable2Step {
             lineaWorldIDAddress, _feeTransferOwnership, message
         );
 
-        emit UpdatedRemoteAddressLinea(owner(), _owner);
+        emit OwnershipTransferredLinea(owner(), _owner, _isLocal);
     }
 
     /// @notice Sets or updates the message service
     /// @param _messageService The new message service address, cannot be empty.
-    function setMessageService(address _messageService) public payable onlyOwner {
+    function setMessageServiceLinea(address _messageService) public payable onlyOwner {
         if (_messageService == address(0)) {
             revert AddressZero();
         }
@@ -176,7 +175,7 @@ contract LineaStateBridge is Ownable2Step {
             lineaWorldIDAddress, _feeSetMessageService, message
         );
 
-        emit UpdatedMessageServiceLinea(owner(), _messageService);
+        emit MessageServiceUpdatedLinea(_messageService);
     }
 
     /// @notice Adds functionality to the StateBridge to set the root history expiry on LineaWorldID
@@ -221,9 +220,9 @@ contract LineaStateBridge is Ownable2Step {
         emit SetFeeTransferOwnershipLinea(_lineaFee);
     }
 
-    /// @notice Sets the fee for the setMessageService method
-    /// @param _lineaFee The new fee for the setMessageService method
-    function setFeeSetMessageService(uint256 _lineaFee) external onlyOwner {
+    /// @notice Sets the fee for the setMessageServiceLinea method
+    /// @param _lineaFee The new fee for the setMessageServiceLinea method
+    function setFeeSetMessageServiceLinea(uint256 _lineaFee) external onlyOwner {
         _feeSetMessageService = _lineaFee;
         emit SetFeeSetMessageService(_lineaFee);
     }

--- a/src/mocks/MockWorldIDIdentityManager.sol
+++ b/src/mocks/MockWorldIDIdentityManager.sol
@@ -40,10 +40,6 @@ contract MockWorldIDIdentityManager is IWorldIDIdentityManager {
     ///        and 7 are the `x` and `y` coordinates for `krs`.
     /// @param preRoot The value for the root of the tree before the `identityCommitments` have been
     ////       inserted. Must be an element of the field `Kr`. (already in reduced form)
-    /// @param startIndex The position in the tree at which the insertions were made.
-    /// @param identityCommitments The identities that were inserted into the tree starting at
-    ///        `startIndex` and `preRoot` to give `postRoot`. All of the commitments must be
-    ///        elements of the field `Kr`.
     /// @param postRoot The root obtained after inserting all of `identityCommitments` into the tree
     ///        described by `preRoot`. Must be an element of the field `Kr`. (alread in reduced form)
     ///

--- a/test/LineaStateBridge.t.sol
+++ b/test/LineaStateBridge.t.sol
@@ -18,8 +18,6 @@ contract LineaStateBridgeTest is PRBTest, StdCheats {
     LineaStateBridge public lineaStateBridge;
     MockWorldIDIdentityManager public mockWorldID;
 
-    uint32 public lineaGasLimit;
-
     address public mockWorldIDAddress;
 
     address public owner;
@@ -47,18 +45,12 @@ contract LineaStateBridgeTest is PRBTest, StdCheats {
     /// of the LineaWorldID contract to the WorldID Identity Manager contract
     /// @param previousRemoteAddress The previous authorized remote sender for the LineaWorldID contract
     /// @param remoteAddress The authorized remote sender address, cannot be empty
-    event UpdatedRemoteAddressLinea(address indexed previousRemoteAddress, address indexed remoteAddress);
+    event OwnershipTransferredLinea(address indexed previousRemoteAddress, address indexed remoteAddress, bool isLocal);
 
     /// @notice Emitted when the StateBridge changes message service address
     /// of the LineaWorldID contract
-    /// @param previousMessageService The previous message service address for the LineaWorldID contract
     /// @param messageService The message service address, cannot be empty.
-    event UpdatedMessageServiceLinea(address indexed previousMessageService, address indexed messageService);
-
-    /// @notice Emitted when the message service is set or updated
-    /// @param oldMessageService The old message service address.
-    /// @param newMessageService The new message service address.
-    event MessageServiceUpdated(address indexed oldMessageService, address indexed newMessageService);
+    event MessageServiceUpdatedLinea(address indexed messageService);
 
     /// @notice Emitted when the StateBridge sends a root to the LineaWorldID contract
     /// @param root The root sent to the LineaWorldID contract on Linea
@@ -123,7 +115,7 @@ contract LineaStateBridgeTest is PRBTest, StdCheats {
         assertEq(vm.activeFork(), mainnetFork);
     }
 
-    function test_propagateRoot_suceeds() public {
+    function test_propagateRoot_succeeds() public {
         vm.expectEmit(true, true, true, true);
         emit RootPropagated(sampleRoot);
 
@@ -159,7 +151,7 @@ contract LineaStateBridgeTest is PRBTest, StdCheats {
         vm.assume(newOwner != address(0));
         vm.expectEmit(true, true, true, true);
 
-        emit UpdatedRemoteAddressLinea(owner, newOwner);
+        emit OwnershipTransferredLinea(owner, newOwner, isLocal);
 
         vm.prank(owner);
         lineaStateBridge.transferOwnershipLinea(newOwner, isLocal);
@@ -171,10 +163,10 @@ contract LineaStateBridgeTest is PRBTest, StdCheats {
         vm.assume(_messageService != address(0));
         vm.expectEmit(true, true, true, true);
 
-        emit UpdatedMessageServiceLinea(owner, _messageService);
+        emit MessageServiceUpdatedLinea(_messageService);
 
         vm.prank(owner);
-        lineaStateBridge.setMessageService(_messageService);
+        lineaStateBridge.setMessageServiceLinea(_messageService);
     }
 
     /// @notice tests whether the StateBridge contract can set root history expiry on Linea
@@ -190,8 +182,6 @@ contract LineaStateBridgeTest is PRBTest, StdCheats {
     /// @notice tests whether the StateBridge contract can set fee for propagateRoot
     /// @param _lineaFee The new lineaFee for SetRootHistoryExpiry
     function test_owner_setFeePropagateRoot_succeeds(uint32 _lineaFee) public {
-        vm.assume(_lineaFee != 0);
-
         vm.expectEmit(true, true, true, true);
 
         emit SetFeePropagateRoot(_lineaFee);
@@ -227,7 +217,7 @@ contract LineaStateBridgeTest is PRBTest, StdCheats {
     }
 
     /// @notice tests whether the StateBridge contract can set fee for SetRootHistoryExpiry
-    /// @param _lineaFee The new lineaFee for setMessageService
+    /// @param _lineaFee The new lineaFee for setMessageServiceLinea
     function test_owner_setFeeSetMessageService_succeeds(uint32 _lineaFee) public {
         vm.assume(_lineaFee != 0);
 
@@ -236,7 +226,7 @@ contract LineaStateBridgeTest is PRBTest, StdCheats {
         emit SetFeeSetMessageService(_lineaFee);
 
         vm.prank(owner);
-        lineaStateBridge.setFeeSetMessageService(_lineaFee);
+        lineaStateBridge.setFeeSetMessageServiceLinea(_lineaFee);
     }
 
     ///////////////////////////////////////////////////////////////////
@@ -324,6 +314,6 @@ contract LineaStateBridgeTest is PRBTest, StdCheats {
         vm.expectRevert(AddressZero.selector);
 
         vm.prank(owner);
-        lineaStateBridge.setMessageService(address(0));
+        lineaStateBridge.setMessageServiceLinea(address(0));
     }
 }


### PR DESCRIPTION
LineaStataBridge.sol:
- Renamed `UpdatedRemoteAddressLinea` to `OwnershipTransferredLinea` and added `isLocal` arg
- Renamed `UpdatedMessageServiceLinea` to `MessageServiceUpdatedLinea` and removed `previousMessageService` key because it couldn't be trustfully filled
- Update comment before `propagateRoot` to better match the current bridge
- Renamed `UpdatedRemoteAddressLinea` to `OwnershipTransferredLinea`
- Renamed `setMessageService` to `setMessageServiceLinea` and `setFeeSetMessageService` to `setFeeSetMessageServiceLinea`

Tests:
Make the necessary updates to match the above changes, fix minor inconsistencies
